### PR TITLE
feat(audio): implementa AudioPlayerViewModel con ExoPlayer y control de reproducción

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -7,10 +7,10 @@
       </SelectionState>
       <SelectionState runConfigName="MainActivity">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-05-06T16:04:33.133687606Z">
+        <DropdownSelection timestamp="2025-05-10T14:29:56.172666924Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/me/.android/avd/Medium_Phone.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/home/me/.android/avd/Pixel_7_Pro.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,11 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.8.9")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
 
+    // TopSheetScaffold
+    implementation("androidx.compose.material3:material3:1.0.0")
+    implementation("androidx.compose.foundation:foundation:1.0.0")
+    implementation("androidx.compose.ui:ui:1.0.0")
+
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
+++ b/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -27,6 +29,8 @@ import androidx.navigation.compose.rememberNavController
 import com.example.soundbeat_test.navigation.GetNavItemList
 import com.example.soundbeat_test.navigation.NavItem
 import com.example.soundbeat_test.navigation.ROUTES
+import com.example.soundbeat_test.ui.audio.AudioPlayerViewModel
+import com.example.soundbeat_test.ui.audio.MusicPlayerBottomSheet
 import com.example.soundbeat_test.ui.screens.auth.LoginScreen
 import com.example.soundbeat_test.ui.screens.auth.RegisterScreen
 import com.example.soundbeat_test.ui.screens.configuration.ConfigurationScreen
@@ -48,7 +52,11 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             SoundBeat_TestTheme {
-                MainApp()
+                val audioPlayerViewModel: AudioPlayerViewModel = viewModel()
+
+                MusicPlayerBottomSheet(audioPlayerViewModel = audioPlayerViewModel) {
+                    MainApp()
+                }
             }
         }
     }
@@ -131,7 +139,7 @@ fun MainScreen(navHosController: NavHostController) {
 private fun BottomNavigationBar(
     navItemList: List<NavItem>, selectedIndex: Int, onInteraction: (Int) -> Unit
 ) {
-    NavigationBar {
+    NavigationBar(Modifier.padding(bottom = 32.dp)) {
         navItemList.forEachIndexed { index, navItem ->
             NavigationBarItem(
                 selected = selectedIndex == index,
@@ -150,6 +158,7 @@ private fun BottomNavigationBar(
  * Renderiza el contenido dinámico de la pantalla dependiendo del índice seleccionado en la barra inferior.
  *
  * @param selectedIndex Índice del elemento seleccionado que define qué pantalla se muestra.
+ * @param navHostController Controlador encargado de la navegación de pantallas.
  */
 @Composable
 fun ContentScreen(

--- a/app/src/main/java/com/example/soundbeat_test/network/api.kt
+++ b/app/src/main/java/com/example/soundbeat_test/network/api.kt
@@ -12,7 +12,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
 
-const val URL_BASE = "http://10.0.2.2:8080"
+const val URL_BASE = "http://192.168.1.174:8080"
 
 /**
  * Función para hacer peticiones a la API, tanto GET como POST, con el manejo adecuado de respuestas y errores.

--- a/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioController.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioController.kt
@@ -1,0 +1,147 @@
+package com.example.soundbeat_test.ui.audio
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+/**
+ * Composable que implementa un BottomSheet con controles de reproducción de música.
+ *
+ * @param audioPlayerViewModel ViewModel encargado de la reproducción de canciones.
+ * @param content Contenido principal que se muestra detrás del reproductor.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MusicPlayerBottomSheet(
+    audioPlayerViewModel: AudioPlayerViewModel,
+    content: @Composable () -> Unit
+) {
+    val bottomSheetState = rememberBottomSheetScaffoldState()
+    val coroutineScope = rememberCoroutineScope()
+
+    val isPlaying by audioPlayerViewModel.isPlaying.collectAsState()
+    val currentMediaItem by audioPlayerViewModel.currentMediaItem.collectAsState()
+
+    BottomSheetScaffold(
+        scaffoldState = bottomSheetState,
+        sheetContent = {
+            MusicPlayerControls(
+                isPlaying = isPlaying,
+                currentTrack = currentMediaItem?.mediaMetadata?.title?.toString() ?: "Sin título",
+                onPlayPauseClick = {
+                    audioPlayerViewModel.playPause()
+                },
+                onNextTrackClick = {
+                    audioPlayerViewModel.skipToNext()
+                },
+                onPreviousTrackClick = {
+                    audioPlayerViewModel.skipToPrevious()
+                },
+                onAddToFavorites = {
+                    audioPlayerViewModel.addToFavorites()
+                },
+                onSaveTrack = {
+                    audioPlayerViewModel.saveTrack()
+                }
+            )
+        },
+        sheetPeekHeight = 56.dp,
+        content = {
+            content()
+
+            // Botón para abrir el reproductor
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        bottomSheetState.bottomSheetState.expand()
+                    }
+                },
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text("Abrir Reproductor")
+            }
+        }
+    )
+}
+
+/**
+ * Composable que muestra los controles de reproducción de música.
+ *
+ * @param isPlaying Estado que indica si hay reproducción activa.
+ * @param currentTrack Nombre de la canción actual.
+ * @param onPlayPauseClick Acción al pulsar el botón de reproducción/pausa.
+ * @param onNextTrackClick Acción al pulsar el botón de siguiente canción.
+ * @param onPreviousTrackClick Acción al pulsar el botón de canción anterior.
+ * @param onAddToFavorites Acción al pulsar el botón de favoritos.
+ * @param onSaveTrack Acción al pulsar el botón de salvar.
+ */
+@Composable
+fun MusicPlayerControls(
+    isPlaying: Boolean,
+    currentTrack: String,
+    onPlayPauseClick: () -> Unit,
+    onNextTrackClick: () -> Unit,
+    onPreviousTrackClick: () -> Unit,
+    onAddToFavorites: () -> Unit,
+    onSaveTrack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Text("Reproduciendo: $currentTrack", style = MaterialTheme.typography.bodySmall)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            IconButton(onClick = onSaveTrack) {
+                Icon(Icons.Default.Save, contentDescription = "Guardar Canción")
+            }
+            IconButton(onClick = onAddToFavorites) {
+                Icon(Icons.Default.FavoriteBorder, contentDescription = "Añadir a Favoritos")
+            }
+            IconButton(onClick = onPreviousTrackClick) {
+                Icon(Icons.Default.FastRewind, contentDescription = "Anterior Canción")
+            }
+            IconButton(onClick = onPlayPauseClick) {
+                Icon(
+                    imageVector = if (isPlaying) Icons.Default.Stop else Icons.Default.PlayArrow,
+                    contentDescription = if (isPlaying) "Pausar" else "Reproducir"
+                )
+            }
+            IconButton(onClick = onNextTrackClick) {
+                Icon(Icons.Default.FastForward, contentDescription = "Siguiente Canción")
+            }
+
+        }
+    }
+}

--- a/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioPlayerViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioPlayerViewModel.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import com.example.soundbeat_test.network.URL_BASE
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -61,6 +62,7 @@ class AudioPlayerViewModel(
 
     init {
         exoPlayer.addListener(listener)
+        loadAndPlayHLS("$URL_BASE/media/Alone_-_Color_Out.m3u8")
     }
 
     /**
@@ -108,6 +110,29 @@ class AudioPlayerViewModel(
     fun seekTo(positionMs: Long) {
         exoPlayer.seekTo(positionMs)
     }
+
+    /**
+     * Agrega la pista actual a la lista de favoritos del usuario.
+     *
+     * Esta función debe implementar la lógica necesaria para marcar una canción
+     * como favorita, lo cual puede implicar persistencia en base de datos local
+     * o sincronización con un servidor.
+     */
+    fun addToFavorites() {
+        // TODO("Not implemented yet.")
+    }
+
+    /**
+     * Guarda la pista actual para su uso offline o posterior reproducción.
+     *
+     * Esta función debería implementar la lógica para almacenar una canción
+     * en almacenamiento local o en una base de datos interna, dependiendo de los
+     * requisitos de la aplicación.
+     */
+    fun saveTrack() {
+        // TODO("Not implemented yet.")
+    }
+
 
     /**
      * Libera los recursos del ExoPlayer y elimina el listener cuando el ViewModel es destruido.

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+
+    <!-- Configuración global para permitir tráfico HTTP en todos los dominios -->
+    <base-config cleartextTrafficPermitted="true" />
+
+    <!-- Permitir HTTP explícitamente a estos dominios -->
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">192.168.1.174</domain>
         <domain includeSubdomains="true">10.0.2.2</domain>
-        <network-security-config>
-            <base-config cleartextTrafficPermitted="true" />
-        </network-security-config>
     </domain-config>
 
 </network-security-config>


### PR DESCRIPTION
### Descripción

Este PR introduce la clase `AudioPlayerViewModel`, encargada de gestionar la lógica de reproducción de audio utilizando ExoPlayer. Este componente central permite controlar la reproducción desde múltiples partes de la interfaz, y expone el estado mediante `StateFlow` para una integración sencilla con Jetpack Compose.

Se hereda de `AndroidViewModel` para poder acceder al `ApplicationContext`, necesario para instanciar correctamente el reproductor. También se incluye la gestión completa del ciclo de vida del `ExoPlayer`, liberando los recursos al cerrar.

#### Cambios incluidos

- Implementación de `AudioPlayerViewModel`
- Reproducción de contenido HLS desde URL
- Control de reproducción: play, pause, siguiente, anterior, seek
- Exposición del estado de reproducción y del `MediaItem` actual mediante `StateFlow`
- Eliminación del `Player.Listener` y liberación de recursos en `onCleared()`
- Aplicación de actualizaciones sugeridas por Android Studio (incluyendo Gradle)

Este PR establece la base del sistema de audio de la aplicación, permitiendo futuras integraciones en la UI de forma reactiva y modular.
