### PR TITLE
Mejoras visuales y funcionales significativas a los controles de reproducción de música.

### DIFF
--- a/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioController.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioController.kt
@@ -1,25 +1,10 @@
 package com.example.soundbeat_test.ui.audio
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FastForward
-import androidx.compose.material.icons.filled.FastRewind
-import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -27,6 +12,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.media3.common.util.Log
+import androidx.media3.common.util.UnstableApi
+import com.example.soundbeat_test.ui.components.PlayerControls
 import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
 
 /**
@@ -46,35 +34,33 @@ fun MusicPlayerBottomSheet(
     val coroutineScope = rememberCoroutineScope()
 
     val isPlaying by audioPlayerViewModel.isPlaying.collectAsState()
+    val mediaItem by audioPlayerViewModel.currentMediaItem.collectAsState()
+    val songName = mediaItem?.mediaMetadata?.title ?: "No title"
+    val author = mediaItem?.mediaMetadata?.artist ?: "No author"
 
-    BottomSheetScaffold(
-        scaffoldState = bottomSheetState,
-        sheetContent = {
-            MusicPlayerControls(
-                isPlaying = isPlaying,
-                currentTrack = "Sin título",
-                onPlayPauseClick = {
-                    audioPlayerViewModel.playPause()
-                },
-                onNextTrackClick = {
-                    audioPlayerViewModel.skipToNext()
-                },
-                onPreviousTrackClick = {
-                    audioPlayerViewModel.skipToPrevious()
-                },
-                onAddToFavorites = {
-                    audioPlayerViewModel.addToFavorites()
-                },
-                onSaveTrack = {
-                    audioPlayerViewModel.saveTrack()
-                }
-            )
-        },
-        sheetPeekHeight = 56.dp,
-        content = {
-            content()
-        }
-    )
+    BottomSheetScaffold(scaffoldState = bottomSheetState, sheetContent = {
+        MusicPlayerControls(
+            isPlaying = isPlaying,
+            currentTrack = songName.toString(),
+            author = author.toString(),
+            onPlayPauseClick = {
+                audioPlayerViewModel.playPause()
+            },
+            onNextTrackClick = {
+                audioPlayerViewModel.skipToNext()
+            },
+            onPreviousTrackClick = {
+                audioPlayerViewModel.skipToPrevious()
+            },
+            onAddToFavorites = {
+                audioPlayerViewModel.addToFavorites()
+            },
+            onSaveTrack = {
+                audioPlayerViewModel.saveTrack()
+            })
+    }, sheetPeekHeight = 56.dp, content = {
+        content()
+    })
 }
 
 /**
@@ -88,47 +74,34 @@ fun MusicPlayerBottomSheet(
  * @param onAddToFavorites Acción al pulsar el botón de favoritos.
  * @param onSaveTrack Acción al pulsar el botón de salvar.
  */
+@androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun MusicPlayerControls(
     isPlaying: Boolean,
     currentTrack: String,
+    author: String,
     onPlayPauseClick: () -> Unit,
     onNextTrackClick: () -> Unit,
     onPreviousTrackClick: () -> Unit,
     onAddToFavorites: () -> Unit,
     onSaveTrack: () -> Unit
 ) {
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp)
+            .padding(bottom = 20.dp)
     ) {
-        Text("Reproduciendo: $currentTrack", style = MaterialTheme.typography.bodySmall)
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center
-        ) {
-            IconButton(onClick = onAddToFavorites) {
-                Icon(Icons.Default.FavoriteBorder, contentDescription = "Añadir a Favoritos")
-            }
-            IconButton(onClick = onPreviousTrackClick) {
-                Icon(Icons.Default.FastRewind, contentDescription = "Anterior Canción")
-            }
-            IconButton(onClick = onPlayPauseClick) {
-                Icon(
-                    imageVector = if (isPlaying) Icons.Default.Stop else Icons.Default.PlayArrow,
-                    contentDescription = if (isPlaying) "Pausar" else "Reproducir"
-                )
-            }
-            IconButton(onClick = onNextTrackClick) {
-                Icon(Icons.Default.FastForward, contentDescription = "Siguiente Canción")
-            }
-            IconButton(onClick = onSaveTrack) {
-                Icon(Icons.Default.Save, contentDescription = "Guardar Canción")
-            }
-
-        }
+        Log.d("AudioController", "Canción: $currentTrack by $author")
+        PlayerControls(
+            songName = currentTrack,
+            author = author,
+            isPlaying = isPlaying,
+            onPlayPauseClick = onPlayPauseClick,
+            onNextTrackClick = onNextTrackClick,
+            onPreviousTrackClick = onPreviousTrackClick,
+            onAddToFavorites = onAddToFavorites,
+            onSaveTrack = onSaveTrack
+        )
     }
 }

--- a/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioPlayerViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioPlayerViewModel.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import androidx.annotation.OptIn
 import androidx.lifecycle.AndroidViewModel
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
@@ -72,21 +73,38 @@ class AudioPlayerViewModel(
 
     init {
         exoPlayer.addListener(listener)
-        // Ejemplo de reproducción de playlist que hice.
-        // val list = Album.AlbumListExample
-        // loadPlaylist(list)
+//         Ejemplo de reproducción de playlist que hice.
+        val list = Album.AlbumListExample
+        loadPlaylist(list)
     }
 
     /**
-     * Carga y reproduce una transmisión de audio en formato HLS.
+     * Carga y reproduce una transmisión de audio en formato HLS con metadatos.
+     *
+     * Esta función reemplaza cualquier contenido anterior del reproductor y comienza a reproducir
+     * automáticamente desde el principio. Se utiliza `MediaItem.Builder` para asociar metadatos
+     * como el título y el autor de la pista.
      *
      * @param url URL de la transmisión HLS a reproducir.
+     * @param title Título de la canción (por ejemplo, el nombre del álbum).
+     * @param artist (Opcional) Nombre del autor o artista.
      */
     @OptIn(UnstableApi::class)
-    fun loadAndPlayHLS(url: String) {
-        exoPlayer.setMediaItem(MediaItem.fromUri(url))
+    fun loadAndPlayHLS(url: String, title: String, artist: String? = null) {
+        val mediaItem = MediaItem.Builder()
+            .setUri(url)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(title)
+                    .setArtist(artist ?: "Autor desconocido")
+                    .build()
+            )
+            .build()
+
+        exoPlayer.setMediaItem(mediaItem)
         exoPlayer.prepare()
         exoPlayer.volume = 1.0f // Volumen máximo
+        exoPlayer.playWhenReady = true
     }
 
     /**
@@ -126,13 +144,25 @@ class AudioPlayerViewModel(
         val mediaItems = albums.map { album ->
             val uri = createSongUrl(album)
             Log.d("AudioPlayerViewModel", "${album.name} : $uri")
-            MediaItem.fromUri(uri)
+
+            MediaItem.Builder()
+                .setUri(uri)
+                .setMediaMetadata(
+                    MediaMetadata.Builder()
+                        .setTitle(album.name)
+                        .setArtist(
+                            album.author ?: "Autor desconocido"
+                        ) // si tienes ese campo en Album
+                        .build()
+                )
+                .build()
         }
 
         exoPlayer.setMediaItems(mediaItems)
         exoPlayer.prepare()
         exoPlayer.playWhenReady = true
     }
+
 
     /**
      * Pausa o reanuda la reproducción del audio actual.

--- a/app/src/main/java/com/example/soundbeat_test/ui/components/VinylDisplay.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/components/VinylDisplay.kt
@@ -17,6 +17,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -116,6 +125,73 @@ fun AlbumCard(album: Album = Album.AlbumExample, onClickedAlbumCover: () -> Unit
                             .background(Color(0xFF7DA1C5), RoundedCornerShape(12.dp))
                             .padding(horizontal = 8.dp, vertical = 4.dp)
                     )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PlayerControls(
+    songName: String = "Unknown",
+    author: String = "Unknown",
+    isPlaying: Boolean = false,
+    onPlayPauseClick: () -> Unit = {},
+    onNextTrackClick: () -> Unit = {},
+    onPreviousTrackClick: () -> Unit = {},
+    onAddToFavorites: () -> Unit = {},
+    onSaveTrack: () -> Unit = {}
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFFF0F0F0), shape = RoundedCornerShape(8.dp))
+            .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AlbumCover()
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = songName,
+                fontWeight = FontWeight.Bold,
+                fontSize = 16.sp,
+                maxLines = 1
+            )
+            Text(
+                text = "by $author",
+                fontSize = 13.sp,
+                color = Color.DarkGray,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset(x = (-14).dp),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                IconButton(onClick = onAddToFavorites) {
+                    Icon(Icons.Default.FavoriteBorder, contentDescription = "Añadir a Favoritos")
+                }
+                IconButton(onClick = onPreviousTrackClick) {
+                    Icon(Icons.Default.FastRewind, contentDescription = "Anterior Canción")
+                }
+                IconButton(onClick = onPlayPauseClick) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Stop else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlaying) "Pausar" else "Reproducir"
+                    )
+                }
+                IconButton(onClick = onNextTrackClick) {
+                    Icon(Icons.Default.FastForward, contentDescription = "Siguiente Canción")
+                }
+                IconButton(onClick = onSaveTrack) {
+                    Icon(Icons.Default.Save, contentDescription = "Guardar Canción")
                 }
             }
         }

--- a/app/src/main/java/com/example/soundbeat_test/ui/selected_playlist/SelectedPlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/selected_playlist/SelectedPlaylistScreen.kt
@@ -109,7 +109,11 @@ fun SelectedPlaylistScreen(
                 albumList = playlist?.songs!!.toList()
             ) { album ->
                 val url: String = audioPlayerViewModel?.createSongUrl(album).toString()
-                audioPlayerViewModel?.loadAndPlayHLS(url)
+                audioPlayerViewModel?.loadAndPlayHLS(
+                    url = url,
+                    title = album.name,
+                    artist = album.author,
+                )
                 Log.d("SelectedPlaylistScreen", "Started playing ${album.name} by ${album.author}")
             }
 


### PR DESCRIPTION
# Descripción

Se han mejorado las visuales y las funciones de los controles de música ubicados en la parte inferior de la pantalla dentro de un desplegable. Antes, los controles de música tenían unas visuales simples. El título de la canción y su artista eran representados en una etiqueta son personalización, y lo mismo sucedía con los controles de reproducir, avanzar canción, etcétera. Se les ha dado un formato visual para que sea más cómodo a la vista y ahora el nombre de la canción y su artista cambian dependiendo de la canción que se esté reproduciendo en su turno. 

# Implementar a futuro

Se me ha olvidado implementar una barra que indique cuanto falta para que termine la canción.