### PR TITLE
Implementación de Playlists locales y su capacidad de creación

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -59,6 +60,36 @@ dependencies {
     implementation("androidx.compose.material3:material3:1.0.0")
     implementation("androidx.compose.foundation:foundation:1.0.0")
     implementation("androidx.compose.ui:ui:1.0.0")
+
+    val room_version = "2.7.1"
+
+    implementation("androidx.room:room-runtime:$room_version")
+
+    // If this project uses any Kotlin source, use Kotlin Symbol Processing (KSP)
+    // See Add the KSP plugin to your project
+    ksp("androidx.room:room-compiler:$room_version")
+
+    // If this project only uses Java source, use the Java annotationProcessor
+    // No additional plugins are necessary
+    annotationProcessor("androidx.room:room-compiler:$room_version")
+
+    // optional - Kotlin Extensions and Coroutines support for Room
+    implementation("androidx.room:room-ktx:$room_version")
+
+    // optional - RxJava2 support for Room
+    implementation("androidx.room:room-rxjava2:$room_version")
+
+    // optional - RxJava3 support for Room
+    implementation("androidx.room:room-rxjava3:$room_version")
+
+    // optional - Guava support for Room, including Optional and ListenableFuture
+    implementation("androidx.room:room-guava:$room_version")
+
+    // optional - Test helpers
+    testImplementation("androidx.room:room-testing:$room_version")
+
+    // optional - Paging 3 Integration
+    implementation("androidx.room:room-paging:$room_version")
 
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
+++ b/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
@@ -35,11 +35,12 @@ import com.example.soundbeat_test.ui.screens.auth.RegisterScreen
 import com.example.soundbeat_test.ui.screens.configuration.ConfigurationScreen
 import com.example.soundbeat_test.ui.screens.create_playlist.CreatePlaylistScreen
 import com.example.soundbeat_test.ui.screens.create_playlist.CreatePlaylistViewModel
+import com.example.soundbeat_test.ui.screens.create_playlist.CreationMode
 import com.example.soundbeat_test.ui.screens.home.HomeScreen
 import com.example.soundbeat_test.ui.screens.playlists.PlaylistScreen
 import com.example.soundbeat_test.ui.screens.playlists.PlaylistScreenViewModel
 import com.example.soundbeat_test.ui.screens.profile.ProfileScreen
-import com.example.soundbeat_test.ui.screens.search.MODE
+import com.example.soundbeat_test.ui.screens.search.SearchInteractionMode
 import com.example.soundbeat_test.ui.screens.search.SearchScreen
 import com.example.soundbeat_test.ui.screens.selected_playlist.SelectedPlaylistScreen
 import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
@@ -60,17 +61,22 @@ class MainActivity : ComponentActivity() {
                 val sharedPlaylistViewModel: SharedPlaylistViewModel = viewModel()
                 val playlistScreenViewModel: PlaylistScreenViewModel = viewModel()
                 val createPlaylistViewModel: CreatePlaylistViewModel = viewModel()
+                Scaffold { it ->
+                    Column(Modifier.padding(it)) {
+                        MusicPlayerBottomSheet(
+                            audioPlayerViewModel = audioPlayerViewModel,
+                            sharedPlaylistViewModel = sharedPlaylistViewModel
+                        ) {
+                            MainApp(
+                                audioPlayerViewModel = audioPlayerViewModel,
+                                sharedPlaylistViewModel = sharedPlaylistViewModel,
+                                playlistScreenViewModel = playlistScreenViewModel,
+                                createPlaylistViewModel = createPlaylistViewModel
+                            )
+                        }
 
-                MusicPlayerBottomSheet(
-                    audioPlayerViewModel = audioPlayerViewModel,
-                    sharedPlaylistViewModel = sharedPlaylistViewModel
-                ) {
-                    MainApp(
-                        audioPlayerViewModel = audioPlayerViewModel,
-                        sharedPlaylistViewModel = sharedPlaylistViewModel,
-                        playlistScreenViewModel = playlistScreenViewModel,
-                        createPlaylistViewModel = createPlaylistViewModel
-                    )
+                    }
+
                 }
             }
         }
@@ -153,24 +159,36 @@ fun AppNavigation(
         }
         composable("SEARCH/{mode}") { backStackEntry ->
             val modeArg = backStackEntry.arguments?.getString("mode")
-            val mode = try {
-                MODE.valueOf(modeArg ?: MODE.NORMAL.name)
+            val searchInteractionMode = try {
+                SearchInteractionMode.valueOf(
+                    modeArg ?: SearchInteractionMode.REPRODUCE_ON_SELECT.name
+                )
             } catch (e: IllegalArgumentException) {
-                MODE.NORMAL
+                SearchInteractionMode.REPRODUCE_ON_SELECT
             }
 
             SearchScreen(
                 navHostController = navController,
                 sharedPlaylistViewModel = sharedPlaylistViewModel!!,
-                mode = mode
+                searchInteractionMode = searchInteractionMode
             )
         }
-        composable(ROUTES.PLAYLIST_CREATOR) {
+        // navController.navigate("PLAYLIST_CREATOR/${CreationMode.ONLINE_PLAYLIST.name}")
+        composable("PLAYLIST_CREATOR/{mode}") { backStackEntry ->
+            val modeArg = backStackEntry.arguments?.getString("mode")
+            val creationMode = try {
+                CreationMode.valueOf(
+                    modeArg ?: CreationMode.OFFLINE_PLAYLIST.name
+                )
+            } catch (e: IllegalArgumentException) {
+                CreationMode.OFFLINE_PLAYLIST
+            }
             CreatePlaylistScreen(
                 navController = navController,
                 playerViewModel = audioPlayerViewModel!!,
                 sharedPlaylistViewModel = sharedPlaylistViewModel!!,
                 createPlaylistViewModel = createPlaylistViewModel,
+                creationMode = creationMode
             )
         }
     }
@@ -260,7 +278,7 @@ fun ContentScreen(
         2 -> SearchScreen(
             navHostController = navHostController,
             sharedPlaylistViewModel = sharedPlaylistViewModel!!,
-            mode = MODE.NORMAL
+            searchInteractionMode = SearchInteractionMode.REPRODUCE_ON_SELECT
         )
 
         3 -> ProfileScreen(navHostController)

--- a/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
+++ b/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
@@ -42,8 +42,8 @@ import com.example.soundbeat_test.ui.screens.playlists.PlaylistScreenViewModel
 import com.example.soundbeat_test.ui.screens.profile.ProfileScreen
 import com.example.soundbeat_test.ui.screens.search.MODE
 import com.example.soundbeat_test.ui.screens.search.SearchScreen
-import com.example.soundbeat_test.ui.selected_playlist.SelectedPlaylistScreen
-import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SelectedPlaylistScreen
+import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 import com.example.soundbeat_test.ui.theme.SoundBeat_TestTheme
 
 /**

--- a/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
+++ b/app/src/main/java/com/example/soundbeat_test/MainActivity.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
@@ -84,7 +83,6 @@ class MainActivity : ComponentActivity() {
  * Muestra toda la estructura de navegación y contenido de la app.
  * Se utiliza en el `setContent` de la actividad.
  */
-@Preview(showSystemUi = true)
 @Composable
 fun MainApp(
     audioPlayerViewModel: AudioPlayerViewModel? = null,

--- a/app/src/main/java/com/example/soundbeat_test/data/Album.kt
+++ b/app/src/main/java/com/example/soundbeat_test/data/Album.kt
@@ -1,6 +1,7 @@
 package com.example.soundbeat_test.data
 
 import com.example.soundbeat_test.R
+import com.example.soundbeat_test.local.room.entities.Song
 import com.example.soundbeat_test.network.URL_BASE
 
 /**
@@ -64,7 +65,20 @@ data class Album(
                 url = "$URL_BASE/media/Molotov_Heart_-_radionowhere.m3u8",
                 duration = 2.2
             )
-
         )
+
+        /**
+         * Convierte un Album a Song para ser subida a la base de datos.
+         */
+        fun Album.toSong(): Song {
+            return Song(
+                songId = this.id,
+                title = this.name,
+                artist = this.author,
+                duration = (this.duration * 60).toInt(),
+                url = this.url,
+                createdAt = System.currentTimeMillis()
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/soundbeat_test/local/room/DatabaseProvider.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/DatabaseProvider.kt
@@ -2,6 +2,9 @@ package com.example.soundbeat_test.local.room
 
 import android.content.Context
 import androidx.room.Room
+import com.example.soundbeat_test.local.room.dao.PlaylistDao
+import com.example.soundbeat_test.local.room.dao.PlaylistSongDao
+import com.example.soundbeat_test.local.room.dao.SongDao
 
 object DatabaseProvider {
 
@@ -20,4 +23,15 @@ object DatabaseProvider {
         }
     }
 
+    fun getPlaylistDao(context: Context): PlaylistDao {
+        return this.getDatabase(context).playlistDao()!!
+    }
+
+    fun getSongDao(context: Context): SongDao {
+        return this.getDatabase(context).songDao()!!
+    }
+
+    fun getPlaylistSongDao(context: Context): PlaylistSongDao {
+        return this.getDatabase(context).playlistSongDao()!!
+    }
 }

--- a/app/src/main/java/com/example/soundbeat_test/local/room/DatabaseProvider.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/DatabaseProvider.kt
@@ -1,0 +1,23 @@
+package com.example.soundbeat_test.local.room
+
+import android.content.Context
+import androidx.room.Room
+
+object DatabaseProvider {
+
+    @Volatile
+    private var INSTANCE: AppDatabase? = null
+
+    fun getDatabase(context: Context): AppDatabase {
+        return INSTANCE ?: synchronized(this) {
+            val instancia = Room.databaseBuilder(
+                context.applicationContext,
+                AppDatabase::class.java,
+                "database_local.db"
+            ).build()
+            INSTANCE = instancia
+            instancia
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/soundbeat_test/local/room/RoomDatabase.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/RoomDatabase.kt
@@ -1,0 +1,23 @@
+package com.example.soundbeat_test.local.room
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.example.soundbeat_test.local.room.dao.PlaylistDao
+import com.example.soundbeat_test.local.room.dao.PlaylistSongDao
+import com.example.soundbeat_test.local.room.dao.SongDao
+import com.example.soundbeat_test.local.room.entities.Playlist
+import com.example.soundbeat_test.local.room.entities.PlaylistSong
+import com.example.soundbeat_test.local.room.entities.Song
+
+/**
+ * Clase AppDatabase para contener la base de datos. AppDatabase define la configuración
+ * de la base de datos y sirve como el punto de acceso principal de la app a los datos persistentes.
+ *
+ * `https://developer.android.com/training/data-storage/room?hl=es-419#java`
+ */
+@Database(entities = [Song::class, Playlist::class, PlaylistSong::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun songDao(): SongDao?
+    abstract fun playlistDao(): PlaylistDao?
+    abstract fun playlistSongDao(): PlaylistSongDao?
+}

--- a/app/src/main/java/com/example/soundbeat_test/local/room/dao/PlaylistSongDao.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/dao/PlaylistSongDao.kt
@@ -1,0 +1,44 @@
+package com.example.soundbeat_test.local.room.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.soundbeat_test.local.room.entities.PlaylistSong
+import com.example.soundbeat_test.local.room.entities.Song
+
+@Dao
+interface PlaylistSongDao {
+
+    /**
+     * Inserta una relación entre una canción y una playlist.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(playlistSong: PlaylistSong)
+
+    /**
+     * Elimina la relación entre una canción y una playlist.
+     */
+    @Delete
+    suspend fun delete(playlistSong: PlaylistSong)
+
+    /**
+     * Devuelve todas las canciones de una playlist específica.
+     */
+    @Query(
+        """
+        SELECT S.* FROM Songs S
+        INNER JOIN Playlist_Songs PS ON S.song_id = PS.song_id
+        WHERE PS.playlist_id = :playlistId
+        ORDER BY S.created_at DESC
+    """
+    )
+    suspend fun getSongsForPlaylist(playlistId: Int): List<Song>
+
+    /**
+     * Elimina todas las relaciones de canciones para una playlist dada.
+     */
+    @Query("DELETE FROM Playlist_Songs WHERE playlist_id = :playlistId")
+    suspend fun deleteAllSongsFromPlaylist(playlistId: Int)
+}

--- a/app/src/main/java/com/example/soundbeat_test/local/room/dao/PlaylistsDao.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/dao/PlaylistsDao.kt
@@ -1,0 +1,35 @@
+package com.example.soundbeat_test.local.room.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import com.example.soundbeat_test.local.room.entities.Playlist
+
+@Dao
+interface PlaylistDao {
+
+    /**
+     * Inserta una nueva playlist.
+     */
+    @Insert
+    suspend fun insert(playlist: Playlist)
+
+    /**
+     * Elimina una playlist (y todas sus relaciones por cascada).
+     */
+    @Delete
+    suspend fun delete(playlist: Playlist)
+
+    /**
+     * Devuelve todas las playlists ordenadas por fecha de creación descendente.
+     */
+    @Query("SELECT * FROM Playlists ORDER BY created_at DESC")
+    suspend fun getAllPlaylists(): List<Playlist>
+
+    /**
+     * Busca una playlist por nombre exacto.
+     */
+    @Query("SELECT * FROM Playlists WHERE name = :playlistName")
+    suspend fun findByName(playlistName: String): Playlist?
+}

--- a/app/src/main/java/com/example/soundbeat_test/local/room/dao/PlaylistsDao.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/dao/PlaylistsDao.kt
@@ -13,7 +13,7 @@ interface PlaylistDao {
      * Inserta una nueva playlist.
      */
     @Insert
-    suspend fun insert(playlist: Playlist)
+    suspend fun insert(playlist: Playlist): Long
 
     /**
      * Elimina una playlist (y todas sus relaciones por cascada).

--- a/app/src/main/java/com/example/soundbeat_test/local/room/dao/SongDao.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/dao/SongDao.kt
@@ -13,7 +13,7 @@ interface SongDao {
      * Inserta una canción en la base de datos.
      */
     @Insert
-    suspend fun insert(song: Song)
+    suspend fun insert(song: Song): Long
 
     /**
      * Elimina una canción específica.
@@ -32,4 +32,7 @@ interface SongDao {
      */
     @Query("SELECT * FROM Songs WHERE artist = :artistName")
     suspend fun findByArtist(artistName: String): List<Song>
+
+    @Query("SELECT * FROM Songs WHERE title = :title AND artist = :artist LIMIT 1")
+    suspend fun getSongByTitleAndArtist(title: String, artist: String): Song?
 }

--- a/app/src/main/java/com/example/soundbeat_test/local/room/dao/SongDao.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/dao/SongDao.kt
@@ -1,0 +1,35 @@
+package com.example.soundbeat_test.local.room.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import com.example.soundbeat_test.local.room.entities.Song
+
+@Dao
+interface SongDao {
+
+    /**
+     * Inserta una canción en la base de datos.
+     */
+    @Insert
+    suspend fun insert(song: Song)
+
+    /**
+     * Elimina una canción específica.
+     */
+    @Delete
+    suspend fun delete(song: Song)
+
+    /**
+     * Obtiene todas las canciones ordenadas por fecha de creación descendente.
+     */
+    @Query("SELECT * FROM Songs ORDER BY created_at DESC")
+    suspend fun getAllSongs(): List<Song>
+
+    /**
+     * Busca canciones por artista.
+     */
+    @Query("SELECT * FROM Songs WHERE artist = :artistName")
+    suspend fun findByArtist(artistName: String): List<Song>
+}

--- a/app/src/main/java/com/example/soundbeat_test/local/room/entities/Playlist.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/entities/Playlist.kt
@@ -1,0 +1,28 @@
+package com.example.soundbeat_test.local.room.entities
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Representa una playlist o lista de reproducción.
+ *
+ * Esta entidad mapea a la tabla "Playlists" y permite organizar
+ * canciones bajo un nombre común.
+ *
+ * @property playlistId ID único de la playlist, generado automáticamente.
+ * @property name Nombre de la playlist. No puede ser nulo.
+ * @property createdAt Marca temporal que indica cuándo se creó la playlist.
+ */
+@Entity(tableName = "Playlists")
+data class Playlist(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Int = 0,
+
+    val name: String,
+
+    @ColumnInfo(name = "created_at")
+
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/soundbeat_test/local/room/entities/PlaylistSong.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/entities/PlaylistSong.kt
@@ -1,0 +1,37 @@
+package com.example.soundbeat_test.local.room.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+
+/**
+ * Relación muchos a muchos entre canciones y playlists.
+ *
+ * Esta entidad mapea a la tabla "Playlist_Songs", que asocia canciones
+ * con playlists a través de claves foráneas. Permite que una canción
+ * pertenezca a múltiples playlists y viceversa.
+ *
+ * @property playlist_id ID de la playlist a la que pertenece la canción.
+ * @property song_id ID de la canción que está en la playlist.
+ */
+@Entity(
+    tableName = "Playlist_Songs",
+    primaryKeys = ["playlist_id", "song_id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = Playlist::class,
+            parentColumns = ["playlist_id"],
+            childColumns = ["playlist_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = Song::class,
+            parentColumns = ["song_id"],
+            childColumns = ["song_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class PlaylistSong(
+    val playlist_id: Int,
+    val song_id: Int
+)

--- a/app/src/main/java/com/example/soundbeat_test/local/room/entities/Songs.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/entities/Songs.kt
@@ -1,0 +1,20 @@
+package com.example.soundbeat_test.local.room.entities
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "Songs")
+data class Song(
+    @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "song_id") val songId: Int = 0,
+
+    val title: String,
+
+    val artist: String,
+
+    val duration: Int,
+
+    val url: String,
+
+    @ColumnInfo(name = "created_at") val createdAt: Long = System.currentTimeMillis() // Timestamp en milisegundos.
+)

--- a/app/src/main/java/com/example/soundbeat_test/local/room/repositories/PlaylistRepository.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/repositories/PlaylistRepository.kt
@@ -1,0 +1,30 @@
+package com.example.soundbeat_test.local.room.repositories
+
+import com.example.soundbeat_test.local.room.dao.PlaylistDao
+import com.example.soundbeat_test.local.room.entities.Playlist
+
+/**
+ * Repositorio responsable de gestionar el acceso a datos relacionados con las playlists.
+ *
+ * Esta clase actúa como intermediario entre el ViewModel y el DAO de playlists,
+ * proporcionando una capa de abstracción que facilita la gestión de las operaciones
+ * de base de datos como inserciones, eliminaciones, consultas y búsquedas por nombre.
+ */
+class PlaylistRepository(private val playlistDao: PlaylistDao) {
+
+    suspend fun insert(playlist: Playlist) {
+        playlistDao.insert(playlist)
+    }
+
+    suspend fun delete(playlist: Playlist) {
+        playlistDao.delete(playlist)
+    }
+
+    suspend fun getAllPlaylists(): List<Playlist> {
+        return playlistDao.getAllPlaylists()
+    }
+
+    suspend fun findPlaylistByName(name: String): Playlist? {
+        return playlistDao.findByName(name)
+    }
+}

--- a/app/src/main/java/com/example/soundbeat_test/local/room/repositories/PlaylistSongRepository.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/repositories/PlaylistSongRepository.kt
@@ -1,0 +1,31 @@
+package com.example.soundbeat_test.local.room.repositories
+
+import com.example.soundbeat_test.local.room.dao.PlaylistSongDao
+import com.example.soundbeat_test.local.room.entities.PlaylistSong
+import com.example.soundbeat_test.local.room.entities.Song
+
+/**
+ * Repositorio encargado de manejar las relaciones entre canciones y playlists.
+ *
+ * Ofrece métodos para insertar y eliminar asociaciones entre canciones y playlists,
+ * obtener todas las canciones de una playlist específica, y eliminar todas las canciones
+ * asociadas a una playlist determinada. Centraliza la lógica relacionada con la tabla intermedia.
+ */
+class PlaylistSongRepository(private val playlistSongDao: PlaylistSongDao) {
+
+    suspend fun addSongToPlaylist(playlistSong: PlaylistSong) {
+        playlistSongDao.insert(playlistSong)
+    }
+
+    suspend fun removeSongFromPlaylist(playlistSong: PlaylistSong) {
+        playlistSongDao.delete(playlistSong)
+    }
+
+    suspend fun getSongsInPlaylist(playlistId: Int): List<Song> {
+        return playlistSongDao.getSongsForPlaylist(playlistId)
+    }
+
+    suspend fun clearPlaylist(playlistId: Int) {
+        playlistSongDao.deleteAllSongsFromPlaylist(playlistId)
+    }
+}

--- a/app/src/main/java/com/example/soundbeat_test/local/room/repositories/SongRepository.kt
+++ b/app/src/main/java/com/example/soundbeat_test/local/room/repositories/SongRepository.kt
@@ -1,0 +1,30 @@
+package com.example.soundbeat_test.local.room.repositories
+
+import com.example.soundbeat_test.local.room.dao.SongDao
+import com.example.soundbeat_test.local.room.entities.Song
+
+/**
+ * Repositorio para el acceso a datos de canciones.
+ *
+ * Proporciona métodos para insertar nuevas canciones, eliminarlas,
+ * recuperar todas las canciones ordenadas por fecha de creación y buscar canciones por artista.
+ * Facilita la comunicación entre el ViewModel y el DAO sin exponer directamente operaciones de base de datos.
+ */
+class SongRepository(private val songDao: SongDao) {
+
+    suspend fun insert(song: Song) {
+        songDao.insert(song)
+    }
+
+    suspend fun delete(song: Song) {
+        songDao.delete(song)
+    }
+
+    suspend fun getAllSongs(): List<Song> {
+        return songDao.getAllSongs()
+    }
+
+    suspend fun findSongsByArtist(artistName: String): List<Song> {
+        return songDao.findByArtist(artistName)
+    }
+}

--- a/app/src/main/java/com/example/soundbeat_test/navigation/ROUTES.kt
+++ b/app/src/main/java/com/example/soundbeat_test/navigation/ROUTES.kt
@@ -14,7 +14,7 @@ object ROUTES {
     const val PLAYLIST = "PLAYLIST"
     const val PROFILE = "PROFILE"
     const val SEARCH = "SEARCH/{mode}"
-    const val PLAYLIST_CREATOR = "PLAYLIST_CREATOR"
+    const val PLAYLIST_CREATOR = "PLAYLIST_CREATOR/{mode}"
     const val SETTINGS = "SETTINGS"
     const val SELECTED_PLAYLIST = "SELECTED_PLAYLIST"
 }

--- a/app/src/main/java/com/example/soundbeat_test/network/api.kt
+++ b/app/src/main/java/com/example/soundbeat_test/network/api.kt
@@ -17,7 +17,7 @@ import java.net.URLEncoder
 /**
  * Aquí se introduce la dirección IP o dominio del servidor.
  */
-const val URL_BASE = "http://192.168.1.175:8080"
+const val URL_BASE = "http://192.168.1.200:8080"
 
 /**
  * Función para hacer peticiones a la API, tanto GET como POST, con el manejo adecuado de respuestas y errores.

--- a/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioController.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioController.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
 import com.example.soundbeat_test.ui.components.PlayerControls
-import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
 /**
  * Composable que implementa un BottomSheet con controles de reproducción de música.

--- a/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioPlayerViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/audio/AudioPlayerViewModel.kt
@@ -91,6 +91,7 @@ class AudioPlayerViewModel(
      */
     @OptIn(UnstableApi::class)
     fun loadAndPlayHLS(url: String, title: String, artist: String? = null) {
+        Log.d("AudioPlayerViewModel", "url: $url")
         val mediaItem = MediaItem.Builder().setUri(url).setMediaMetadata(
             MediaMetadata.Builder().setTitle(title).setArtist(artist ?: "Autor desconocido")
                 .build()
@@ -117,12 +118,12 @@ class AudioPlayerViewModel(
     fun createSongUrl(album: Album): String {
         val result = if (!album.isLocal) {
             val encodedName = URLEncoder.encode(album.name.trim() + ".m3u8", "UTF-8")
-            "$URL_BASE/media/$encodedName"
-            encodedName
+            val url = "$URL_BASE/media/$encodedName"
+            return url
         } else {
             album.url
         }
-        Log.d("AudioPlayerViewModel", "URL o URI: $result")
+        Log.d("AudioPlayerViewModel", "URL o URI: $result - isLocal: ${album.isLocal}")
         return result
     }
 

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistScreen.kt
@@ -32,7 +32,7 @@ import com.example.soundbeat_test.ui.audio.AudioPlayerViewModel
 import com.example.soundbeat_test.ui.components.AlbumCard
 import com.example.soundbeat_test.ui.components.UserImage
 import com.example.soundbeat_test.ui.screens.search.MODE
-import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
 @OptIn(UnstableApi::class)
 @Composable

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistScreen.kt
@@ -1,6 +1,7 @@
 package com.example.soundbeat_test.ui.screens.create_playlist
 
 import androidx.annotation.OptIn
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -22,6 +23,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
@@ -31,7 +33,7 @@ import com.example.soundbeat_test.navigation.ROUTES
 import com.example.soundbeat_test.ui.audio.AudioPlayerViewModel
 import com.example.soundbeat_test.ui.components.AlbumCard
 import com.example.soundbeat_test.ui.components.UserImage
-import com.example.soundbeat_test.ui.screens.search.MODE
+import com.example.soundbeat_test.ui.screens.search.SearchInteractionMode
 import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
 @OptIn(UnstableApi::class)
@@ -40,7 +42,8 @@ fun CreatePlaylistScreen(
     navController: NavHostController,
     createPlaylistViewModel: CreatePlaylistViewModel,
     playerViewModel: AudioPlayerViewModel,
-    sharedPlaylistViewModel: SharedPlaylistViewModel
+    sharedPlaylistViewModel: SharedPlaylistViewModel,
+    creationMode: CreationMode
 ) {
     val sharedPlaylist = sharedPlaylistViewModel?.selectedPlaylist?.collectAsState()
     val receivedPlaylist = sharedPlaylist?.value
@@ -64,6 +67,17 @@ fun CreatePlaylistScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Row(
+            Modifier
+                .fillMaxWidth()
+                .background(Color(0xFFFF5722)),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(text = "Modo: $creationMode", color = Color.White, fontStyle = FontStyle.Italic)
+        }
+
+        Spacer(modifier = Modifier.height(2.dp))
+
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 20.dp),
@@ -71,7 +85,7 @@ fun CreatePlaylistScreen(
         ) {
             Button(
                 onClick = {
-                    createPlaylistViewModel.createPlaylist()
+                    createPlaylistViewModel.createPlaylist(creationMode)
                 },
                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF5722)),
             ) {
@@ -135,7 +149,7 @@ fun SongsListBox(
             )
             Button(
                 onClick = {
-                    navController?.navigate("search/${MODE.CREATOR.name}")
+                    navController?.navigate("search/${SearchInteractionMode.APPEND_TO_PLAYLIST.name}")
                 },
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF5722)),

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistViewModel.kt
@@ -34,6 +34,7 @@ class CreatePlaylistViewModel(application: Application) : AndroidViewModel(appli
     private val db = DatabaseProvider.getDatabase(application.applicationContext)
     private val localPlaylistDb = db.playlistDao()
     private val localSongDb = db.songDao()
+    private val localPlaylistSongDb = db.playlistSongDao()
 
     private val _playlistName = mutableStateOf("Playlist nº1")
     val playlistName: State<String> = _playlistName
@@ -129,16 +130,15 @@ class CreatePlaylistViewModel(application: Application) : AndroidViewModel(appli
             val playlist = Playlist(
                 name = playlistName.value, createdAt = System.currentTimeMillis()
             )
-            db.playlistDao()?.insert(playlist)
-            val playlistId = db.playlistDao()?.getAllPlaylists()?.last()?.playlistId
+            localPlaylistDb?.insert(playlist)
+            val playlistId = localPlaylistDb?.getAllPlaylists()?.last()?.playlistId
             for (song in _songs.value) {
-                db.songDao()?.insert(song.toSong())
-                val songId = db.songDao()?.getAllSongs()?.last()?.songId
+                localSongDb?.insert(song.toSong())
+                val songId = localSongDb?.getAllSongs()?.last()?.songId
                 var playlistSong = PlaylistSong(
-                    playlist_id = playlistId!!,
-                    song_id = songId!!
+                    playlist_id = playlistId!!, song_id = songId!!
                 )
-                db.playlistSongDao()?.insert(playlistSong)
+                localPlaylistSongDb?.insert(playlistSong)
             }
         }
     }

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/create_playlist/CreatePlaylistViewModel.kt
@@ -9,10 +9,11 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
-import androidx.room.Room
 import com.example.soundbeat_test.data.Album
-import com.example.soundbeat_test.local.room.AppDatabase
+import com.example.soundbeat_test.data.Album.Companion.toSong
+import com.example.soundbeat_test.local.room.DatabaseProvider
 import com.example.soundbeat_test.local.room.entities.Playlist
+import com.example.soundbeat_test.local.room.entities.PlaylistSong
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -27,11 +28,12 @@ enum class CreationMode {
 
 class CreatePlaylistViewModel(application: Application) : AndroidViewModel(application) {
 
-    val db = Room.databaseBuilder(
-        context = application.applicationContext,
-        AppDatabase::class.java,
-        "nombre_de_tu_base_de_datos"
-    ).build()
+    /**
+     * Instancia de la base de datos. Necesaria para agregar y crear Playlists localmente.
+     */
+    private val db = DatabaseProvider.getDatabase(application.applicationContext)
+    private val localPlaylistDb = db.playlistDao()
+    private val localSongDb = db.songDao()
 
     private val _playlistName = mutableStateOf("Playlist nº1")
     val playlistName: State<String> = _playlistName
@@ -39,66 +41,106 @@ class CreatePlaylistViewModel(application: Application) : AndroidViewModel(appli
     private val _songs = MutableStateFlow<Set<Album>>(emptySet())
     val songs: StateFlow<Set<Album>> = _songs
 
+    /**
+     * Actualiza el texto conforme a lo que el usuario esté escribiendo en tiempo real.
+     */
     fun onPlaylistNameChange(newName: String) {
         _playlistName.value = newName
     }
 
+    /**
+     * Agrega una canción a la lista de canciones.
+     */
     fun addSong(album: Album) {
         _songs.value = _songs.value + album
     }
 
+    /**
+     * Remueve una canción almacenada y seleccionada dentro de la lista de canciones.
+     */
     fun removeSong(album: Album) {
         _songs.value = _songs.value - album
     }
 
+    /**
+     * Limpia la lista.
+     */
     fun clearSongsList() {
         _songs.value = emptySet()
     }
 
+    /**
+     * Limpia el nombre de la playlist.
+     */
     fun clearPlaylistName() {
         _playlistName.value = ""
     }
 
+    /**
+     * Crea una Playlist remota o local definida por parámetro.
+     * @param creationMode: Modo de creación de la Playlist.
+     * @see CreationMode
+     */
     @OptIn(UnstableApi::class)
     fun createPlaylist(creationMode: CreationMode) {
         when (creationMode) {
             CreationMode.ONLINE_PLAYLIST -> {
-
-                viewModelScope.launch {
-                    val sharedPreferences = getApplication<Application>().getSharedPreferences(
-                        "UserInfo",
-                        Context.MODE_PRIVATE
-                    )
-                    val userEmail = sharedPreferences.getString("email", null)
-
-                    if (userEmail != null) {
-                        val ids = _songs.value.toList().map { it.id }
-                        com.example.soundbeat_test.network.createPlaylist(
-                            playlistName = playlistName.value,
-                            userEmail = userEmail,
-                            songsId = ids,
-                        )
-                    } else {
-                        // Maneja el caso en que no hay email almacenado
-                        Log.e("createPlaylist", "No se encontró el email en SharedPreferences")
-                    }
-                }
+                createRemotePlaylist()
             }
 
             CreationMode.OFFLINE_PLAYLIST -> {
-                viewModelScope.launch {
-                    val playlist = Playlist(
-                        name = playlistName.value, createdAt = System.currentTimeMillis()
-                    )
-                    db.playlistDao()?.insert(playlist)
-                    db.playlistDao()?.getAllPlaylists()?.last()?.playlistId
-                    for (song in _songs.value) {
-
-                    }
-                }
+                createLocalPlaylist()
             }
         }
     }
 
+    /**
+     * Contacta con la base de datos del servidor y crea una Playlist con las canciones
+     * seleccionadas por el usuario. Las canciones seleccionadas son obtenidas del servidor.
+     */
+    @OptIn(UnstableApi::class)
+    private fun createRemotePlaylist() {
+        viewModelScope.launch {
+            val sharedPreferences = getApplication<Application>().getSharedPreferences(
+                "UserInfo", Context.MODE_PRIVATE
+            )
+            val userEmail = sharedPreferences.getString("email", null)
+
+            if (userEmail != null) {
+                val ids = _songs.value.toList().map { it.id }
+                com.example.soundbeat_test.network.createPlaylist(
+                    playlistName = playlistName.value,
+                    userEmail = userEmail,
+                    songsId = ids,
+                )
+            } else {
+                Log.e("createPlaylist", "No se encontró el email en SharedPreferences")
+            }
+        }
+    }
+
+    /**
+     * Contacta con la base de datos local del sistema y crea una Playlist con las canciones
+     * seleccionadas. Para que las canciones puedan ser agregadas a la playlist, se obtiene
+     * la información de las canciones y se agregan también a la base de datos.
+     */
+    private fun createLocalPlaylist() {
+        viewModelScope.launch {
+            val playlist = Playlist(
+                name = playlistName.value, createdAt = System.currentTimeMillis()
+            )
+            db.playlistDao()?.insert(playlist)
+            val playlistId = db.playlistDao()?.getAllPlaylists()?.last()?.playlistId
+            for (song in _songs.value) {
+                db.songDao()?.insert(song.toSong())
+                val songId = db.songDao()?.getAllSongs()?.last()?.songId
+                var playlistSong = PlaylistSong(
+                    playlist_id = playlistId!!,
+                    song_id = songId!!
+                )
+                db.playlistSongDao()?.insert(playlistSong)
+            }
+        }
+    }
 
 }

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/home/HomeScreen.kt
@@ -23,8 +23,8 @@ import com.example.soundbeat_test.local.listLocalAlbums
 import com.example.soundbeat_test.navigation.ROUTES
 import com.example.soundbeat_test.network.getServerSongs
 import com.example.soundbeat_test.ui.components.AlbumHorizontalList
-import com.example.soundbeat_test.ui.selected_playlist.SelectionMode
-import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SelectionMode
+import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
 @Preview(showSystemUi = true)
 @Composable

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/playlists/PlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/playlists/PlaylistScreen.kt
@@ -18,8 +18,8 @@ import com.example.soundbeat_test.data.Playlist
 import com.example.soundbeat_test.navigation.ROUTES
 import com.example.soundbeat_test.ui.components.AlbumHorizontalList
 import com.example.soundbeat_test.ui.components.TopLargeBottomRowGifLayout
-import com.example.soundbeat_test.ui.selected_playlist.SelectionMode
-import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SelectionMode
+import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
 @Composable
 fun PlaylistScreen(

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/playlists/PlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/playlists/PlaylistScreen.kt
@@ -21,6 +21,7 @@ import com.example.soundbeat_test.ui.components.TopLargeBottomRowGifLayout
 import com.example.soundbeat_test.ui.screens.create_playlist.CreationMode
 import com.example.soundbeat_test.ui.screens.selected_playlist.SelectionMode
 import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SongSource
 
 @Composable
 fun PlaylistScreen(
@@ -28,7 +29,8 @@ fun PlaylistScreen(
     playlistScreenViewModel: PlaylistScreenViewModel,
     sharedPlaylistViewModel: SharedPlaylistViewModel
 ) {
-    val playlists = playlistScreenViewModel.userPlaylists.collectAsState().value
+    val remotePlaylists = playlistScreenViewModel.remoteUserPlaylists.collectAsState().value
+    val localPlaylists = playlistScreenViewModel.localUserPlaylist.collectAsState().value
 
     Box {
         Scaffold { padding ->
@@ -53,10 +55,11 @@ fun PlaylistScreen(
                 ) {
                     Text("¡Tus playlists en línea!")
                     AlbumHorizontalList(
-                        list = playlists
+                        list = remotePlaylists
                     ) { item ->
                         if (item is Playlist) {
                             sharedPlaylistViewModel.setMode(selectionMode = SelectionMode.PLAYLIST)
+                            sharedPlaylistViewModel.setSongsSource(songsSource = SongSource.REMOTES)
                             Log.d("PlaylistScreen", "Playlist: ${item.id} - ${item.name}")
                             sharedPlaylistViewModel.updatePlaylist(item)
                             Log.d(
@@ -72,8 +75,23 @@ fun PlaylistScreen(
                         Log.d("PlaylistScreen", "Navigating to: SELECTED PLAYLIST")
                     }
                     Text("¡Tus playlist locales!")
-                    AlbumHorizontalList {
+                    AlbumHorizontalList(list = localPlaylists) { item ->
+                        if (item is Playlist) {
+                            sharedPlaylistViewModel.setMode(selectionMode = SelectionMode.PLAYLIST)
+                            sharedPlaylistViewModel.setSongsSource(songsSource = SongSource.LOCALS)
+                            Log.d("PlaylistScreen", "Playlist: ${item.id} - ${item.name}")
+                            sharedPlaylistViewModel.updatePlaylist(item)
+                            Log.d(
+                                "PlaylistScreen",
+                                "${sharedPlaylistViewModel.selectedPlaylist.value}"
+                            )
+
+                            navHostController?.navigate(ROUTES.SELECTED_PLAYLIST)
+                            Log.d("PlaylistScreen", "Navigating to: SELECTED PLAYLIST")
+                        }
+
                         navHostController?.navigate(ROUTES.SELECTED_PLAYLIST)
+                        Log.d("PlaylistScreen", "Navigating to: SELECTED PLAYLIST")
                     }
                 }
             }

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/playlists/PlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/playlists/PlaylistScreen.kt
@@ -18,6 +18,7 @@ import com.example.soundbeat_test.data.Playlist
 import com.example.soundbeat_test.navigation.ROUTES
 import com.example.soundbeat_test.ui.components.AlbumHorizontalList
 import com.example.soundbeat_test.ui.components.TopLargeBottomRowGifLayout
+import com.example.soundbeat_test.ui.screens.create_playlist.CreationMode
 import com.example.soundbeat_test.ui.screens.selected_playlist.SelectionMode
 import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
@@ -40,9 +41,11 @@ fun PlaylistScreen(
             ) {
                 TopLargeBottomRowGifLayout(
                     bigImageOnClick = {  /* TODO("Not yet implemented") */ },
-                    leftImageOnClick = { /* TODO("Not yet implemented") */ },
+                    leftImageOnClick = {
+                        navHostController?.navigate("PLAYLIST_CREATOR/${CreationMode.OFFLINE_PLAYLIST.name}")
+                    },
                     rightImageOnClick = {
-                        navHostController?.navigate(ROUTES.PLAYLIST_CREATOR)
+                        navHostController?.navigate("PLAYLIST_CREATOR/${CreationMode.ONLINE_PLAYLIST.name}")
                     })
                 Column(
                     modifier = Modifier.padding(10.dp),

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/profile/ProfileScreen.kt
@@ -27,7 +27,7 @@ import androidx.navigation.NavHostController
 import com.example.soundbeat_test.navigation.ROUTES
 import com.example.soundbeat_test.ui.components.AlbumHorizontalList
 import com.example.soundbeat_test.ui.components.UserImage
-import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
 /**
  * Composable que representa la pantalla de perfil de usuario.

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreen.kt
@@ -26,10 +26,19 @@ import com.example.soundbeat_test.data.Album
 import com.example.soundbeat_test.data.Playlist
 import com.example.soundbeat_test.navigation.ROUTES
 import com.example.soundbeat_test.ui.components.AlbumCard
+import com.example.soundbeat_test.ui.screens.search.SearchInteractionMode.APPEND_TO_PLAYLIST
+import com.example.soundbeat_test.ui.screens.search.SearchInteractionMode.REPRODUCE_ON_SELECT
 import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
-enum class MODE {
-    NORMAL, CREATOR
+/**
+ * Estos son los modos en los que funciona la interfáz.
+ * @param REPRODUCE_ON_SELECT: Reproduce las canciones pinchadas por el usuario.
+ * @param APPEND_TO_PLAYLIST: Cuando `SearchScreen` es llamada para crear una playlist, usa
+ * este modo. Cambia su funcionamiento para en vez de reproducirlas, las sube a
+ * `SharedPlaylistViewModel.kt`
+ */
+enum class SearchInteractionMode {
+    REPRODUCE_ON_SELECT, APPEND_TO_PLAYLIST
 }
 
 /**
@@ -50,7 +59,7 @@ fun SearchScreen(
     navHostController: NavHostController? = null,
     searchScreenViewModel: SearchScreenViewModel = viewModel(),
     sharedPlaylistViewModel: SharedPlaylistViewModel? = null,
-    mode: MODE = MODE.NORMAL
+    searchInteractionMode: SearchInteractionMode = REPRODUCE_ON_SELECT
 ) {
 
     val queryState = searchScreenViewModel.textFieldText.collectAsState()
@@ -74,17 +83,17 @@ fun SearchScreen(
                 VinylList(
                     albumList = list
                 ) { album ->
-                    val playlist: Playlist = Playlist(
+                    val playlist = Playlist(
                         id = 1, name = album.name, songs = setOf(album)
                     )
                     sharedPlaylistViewModel?.updatePlaylist(playlist)
 
-                    when (mode) {
-                        MODE.NORMAL -> {
+                    when (searchInteractionMode) {
+                        REPRODUCE_ON_SELECT -> {
                             navHostController.navigate(ROUTES.SELECTED_PLAYLIST)
                         }
 
-                        MODE.CREATOR -> {
+                        APPEND_TO_PLAYLIST -> {
                             navHostController.navigate(ROUTES.PLAYLIST_CREATOR)
                         }
                     }

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreen.kt
@@ -26,7 +26,7 @@ import com.example.soundbeat_test.data.Album
 import com.example.soundbeat_test.data.Playlist
 import com.example.soundbeat_test.navigation.ROUTES
 import com.example.soundbeat_test.ui.components.AlbumCard
-import com.example.soundbeat_test.ui.selected_playlist.SharedPlaylistViewModel
+import com.example.soundbeat_test.ui.screens.selected_playlist.SharedPlaylistViewModel
 
 enum class MODE {
     NORMAL, CREATOR

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreen.kt
@@ -67,7 +67,7 @@ fun SearchScreen(
                 text = query,
                 onTextChange = { searchScreenViewModel.onSearchQueryChange(it) },
                 onSearch = { query ->
-                    searchScreenViewModel.loadAlbums(query)
+                    searchScreenViewModel.fillSongsList(query)
                 })
 
             navHostController?.let {

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreenViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreenViewModel.kt
@@ -73,7 +73,8 @@ class SearchScreenViewModel() : ViewModel() {
     }
 
     /**
-     * Carga las canciones del servidor. Las canciones pueden ser filtradas por nombre.
+     * Carga canciones locales o remotas dependiendo del modo asignado en que actua el ViewModel.
+     * @see SearchMode
      */
     fun fillSongsList(query: String = "") {
 

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreenViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/search/SearchScreenViewModel.kt
@@ -3,10 +3,23 @@ package com.example.soundbeat_test.ui.screens.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.soundbeat_test.data.Album
+import com.example.soundbeat_test.local.listLocalAlbums
 import com.example.soundbeat_test.network.getServerSongs
+import com.example.soundbeat_test.ui.screens.search.SearchMode.LOCAL
+import com.example.soundbeat_test.ui.screens.search.SearchMode.REMOTE
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+
+/**
+ * Enumera los modos de funcionamiento del ViewModel. Dependiendo del modo elegido el ViewModel
+ * buscará canciones en el servidor remoto o en la carpeta local del usuario.
+ * @property REMOTE: Indica que debe buscar en el servidor remoto.
+ * @property LOCAL: Indica que debe buscar en el almacenamiento local.
+ */
+enum class SearchMode {
+    REMOTE, LOCAL
+}
 
 /**
  * Clase que se encarga de la lógica de la pantalla de búsqueda de canciones.
@@ -17,6 +30,17 @@ class SearchScreenViewModel() : ViewModel() {
         // Se establece conexión con el servidor para traer las canciones especificadas.
         loadAlbums()
     }
+
+    /**
+     * Propiedad que almacena el modo en el que se encuentra el ViewModel.
+     */
+    private val _searchMode = MutableStateFlow<SearchMode>(LOCAL)
+
+    /**
+     * Propiedad de solo lectura que sirve al proposito de ver el modo en el que se encuentra
+     * el ViewModel.
+     */
+    val searchMode: StateFlow<SearchMode> = _searchMode
 
     /**
      * Propiedad que almacena la información del usuario y que puede ser modificada.
@@ -76,23 +100,30 @@ class SearchScreenViewModel() : ViewModel() {
      */
     fun loadAlbums(query: String = "") {
 
-        // Corrutina lanzada para obtener el resultado de la función asíncrona `getServerSongs()`
-        viewModelScope.launch {
+        when (_searchMode.value) {
+            REMOTE -> {
+                viewModelScope.launch {
 
-            val result = getServerSongs()
+                    val result = getServerSongs()
 
-            if (result.isSuccess) {
-                val fullList = result.getOrNull()
-//                _albumList = MutableStateFlow<List<Album>>(result.getOrNull() ?: emptyList<Album>())
-                _albumList.value = (if (query.isBlank()) {
-                    fullList
-                } else {
-                    fullList?.filter { it.name.startsWith(query, ignoreCase = true) }
-                })!!
-            } else {
-                _errorMessage = result.exceptionOrNull()?.message ?: "Error desconocido"
+                    if (result.isSuccess) {
+                        val fullList = result.getOrNull()
+                        _albumList.value = (if (query.isBlank()) {
+                            fullList
+                        } else {
+                            fullList?.filter { it.name.startsWith(query, ignoreCase = true) }
+                        })!!
+                    } else {
+                        _errorMessage = result.exceptionOrNull()?.message ?: "Error desconocido"
+                    }
+                }
+            }
+
+            LOCAL -> {
+                _albumList.value = listLocalAlbums()
             }
         }
+
     }
 
     /**
@@ -102,4 +133,10 @@ class SearchScreenViewModel() : ViewModel() {
         _textFieldText.value = query
     }
 
+    /**
+     * Asigna un modo de búsqueda al ViewModel.
+     */
+    fun setSearchMode(searchMode: SearchMode) {
+        _searchMode.value = searchMode
+    }
 }

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SelectedPlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SelectedPlaylistScreen.kt
@@ -1,4 +1,4 @@
-package com.example.soundbeat_test.ui.selected_playlist
+package com.example.soundbeat_test.ui.screens.selected_playlist
 
 import android.util.Log
 import androidx.compose.foundation.Image

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SelectedPlaylistScreen.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SelectedPlaylistScreen.kt
@@ -64,13 +64,26 @@ fun SelectedPlaylistScreen(
 ) {
     val playlist = sharedPlaylistViewModel.selectedPlaylist.collectAsState().value
     val screenMode = sharedPlaylistViewModel.mode.collectAsState().value
+    val songSource = sharedPlaylistViewModel.songsSource.collectAsState().value
     val songs = playlistScreenViewModel.songs.collectAsState().value
 
-    LaunchedEffect(playlist?.id) {
-        playlist?.let {
-            Log.d("SelectedPlaylistScreen", "Playlist ID: ${it.id}")
-            Log.d("SelectedPlaylistScreen", "Playlist canciones:  ${it.songs}")
-            playlistScreenViewModel.obtainPlaylistSongs(it.id)
+    LaunchedEffect(songSource, playlist?.id) {
+        when (songSource) {
+            SongSource.LOCALS -> {
+                playlist?.let {
+                    Log.d("SelectedPlaylistScreen", "Playlist ID: ${playlist.id}")
+                    Log.d("SelectedPlaylistScreen", "Playlist canciones:  ${playlist.songs}")
+                    playlistScreenViewModel.obtainLocalPlaylistSongs(playlist.id)
+                }
+            }
+
+            SongSource.REMOTES -> {
+                playlist?.let {
+                    Log.d("SelectedPlaylistScreen", "Playlist ID: ${playlist.id}")
+                    Log.d("SelectedPlaylistScreen", "Playlist canciones:  ${playlist.songs}")
+                    playlistScreenViewModel.obtainRemotePlaylistSongs(playlist.id)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SharedPlaylistViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SharedPlaylistViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.soundbeat_test.ui.selected_playlist
+package com.example.soundbeat_test.ui.screens.selected_playlist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SharedPlaylistViewModel.kt
+++ b/app/src/main/java/com/example/soundbeat_test/ui/screens/selected_playlist/SharedPlaylistViewModel.kt
@@ -19,6 +19,13 @@ enum class SelectionMode {
 }
 
 /**
+ * Indica la procedencia de las canciones.
+ */
+enum class SongSource {
+    LOCALS, REMOTES
+}
+
+/**
  * ViewModel compartido para almacenar temporalmente la playlist seleccionada.
  *
  * Esta clase se utiliza como puente de datos entre pantallas: una pantalla selecciona
@@ -46,6 +53,16 @@ class SharedPlaylistViewModel : ViewModel() {
      * ante cambios en la selección de playlist.
      */
     val selectedPlaylist: StateFlow<Playlist?> = _selectedPlaylist
+
+    /**
+     * Almacena la procedencia de las canciones.
+     */
+    private val _songsSource = MutableStateFlow<SongSource>(SongSource.REMOTES)
+
+    /**
+     * Informa si la Playlist que contiene en su interior esta hecha de canciones locales o remotas.
+     */
+    val songsSource: StateFlow<SongSource> = _songsSource
 
     /**
      * Indica si el elemento actualmente seleccionado es una playlist.
@@ -96,6 +113,10 @@ class SharedPlaylistViewModel : ViewModel() {
      */
     fun setMode(selectionMode: SelectionMode) {
         _isPlaylist.value = selectionMode
+    }
+
+    fun setSongsSource(songsSource: SongSource) {
+        _songsSource.value = songsSource
     }
 
     fun deletePlaylist(playlist: Playlist) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
 }


### PR DESCRIPTION
# Descripcion

Implementa la capacidad de crear Playlists locales. Los cambios han sido los siguientes:

- Se ha agregado Room para gestionar canciones, playlists y sus asociaciones
- Se ha dotado de la capacidad de reproducir estas playlists y de crearlas sin inconvenientes.
- Las playlists creadas ahora son visibles desde la pantalla de playlists.